### PR TITLE
Allow attribute for ngcartAddtocart directive

### DIFF
--- a/src/ngCart.directives.js
+++ b/src/ngCart.directives.js
@@ -9,7 +9,7 @@ angular.module('ngCart.directives', ['ngCart.fulfilment'])
 
     .directive('ngcartAddtocart', ['ngCart', function(ngCart){
         return {
-            restrict : 'E',
+            restrict : 'AE',
             controller : 'CartController',
             scope: {
                 id:'@',


### PR DESCRIPTION
CKEditor, a WYSIWYG editor, is screwing custom HTML tags attributes is they have "protected" data, such as used with twig for example, a tag like:
`<ngcart-addtocart id="{$ item.id $}" name="{$ item.name $}" price="{$ item.price $}" quantity="1">Add</ngcart-addtocart>`
is destroyed like that:
`<ngcart-addtocart id="<!--{cke_protected}%7B%24%20item.id%20%24%7D-->" name="<!--{cke_protected}%7B%24%20item.name%20%24%7D-->" price="<!--{cke_protected}%7B%24%20item.price%20%24%7D-->" quantity="1">Add</ngcart-addtocart></div>`

An easy work-around is to use the attribute mode for the directive:
`<div id="{$ item._id $}" name="{$ item.name $}" ngcart-addtocart price="{$ item.price $}" quantity="1">Add</div>`