### PR TITLE
Use phantom js 2 for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: node_js
 node_js:
   - "0.10"
+before_install:
+  - mkdir travis-phantomjs
+  - wget https://s3.amazonaws.com/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -O $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2
+  - tar -xvf $PWD/travis-phantomjs/phantomjs-2.0.0-ubuntu-12.04.tar.bz2 -C $PWD/travis-phantomjs
+  - export PATH=$PWD/travis-phantomjs:$PATH
+  - export PHANTOMJS2_VERSION="2.0.0"
 before_script:
   - npm install -g grunt-cli

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,7 +41,7 @@ module.exports = function (grunt) {
             travis: {
                 configFile: 'karma.conf.js',
                 singleRun: true,
-                browsers: ['PhantomJS']
+                browsers: ['PhantomJS2']
             }
         },
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -19,7 +19,7 @@ module.exports = function (config) {
             'karma-junit-reporter',
             'karma-chrome-launcher',
             'karma-firefox-launcher',
-            'karma-phantomjs-launcher',
+            'karma-phantomjs2-launcher',
             'karma-jasmine'
         ],
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "karma-firefox-launcher": "~0.1.3",
     "karma-jasmine": "~0.1.5",
     "karma-junit-reporter": "^0.2.2",
-    "karma-phantomjs-launcher": "~0.1.4",
+    "karma-phantomjs2-launcher": "~0.4.0",
     "protractor": "~0.20.1",
     "shelljs": "^0.2.6"
   },


### PR DESCRIPTION
Travis builds fail because they run an outdated version of PhantomJS (1.9.8).
These changes allow the tests to run with PhantomJS 2